### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/update-api-specs.yml
+++ b/.github/workflows/update-api-specs.yml
@@ -1,7 +1,7 @@
 name: Update Proxmox API Specifications
 
 permissions:
-  contents: write
+  contents: read
 
 on:
   schedule:
@@ -192,6 +192,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [update-pve-specs, update-pbs-specs]
     if: always() && (needs.update-pve-specs.result == 'success' || needs.update-pbs-specs.result == 'success')
+    permissions:
+      contents: write
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/update-api-specs.yml
+++ b/.github/workflows/update-api-specs.yml
@@ -1,5 +1,8 @@
 name: Update Proxmox API Specifications
 
+permissions:
+  contents: write
+
 on:
   schedule:
     # Run weekly on Sundays at 2 AM UTC


### PR DESCRIPTION
Potential fix for [https://github.com/basher83/Proxmox-OpenAPI/security/code-scanning/4](https://github.com/basher83/Proxmox-OpenAPI/security/code-scanning/4)

To fix the issue, we need to add a `permissions` block to the workflow file. This block should specify the minimal permissions required for each job to complete its tasks. For example:
- Jobs that only read repository contents should have `contents: read`.
- Jobs that commit and push changes should have `contents: write`.

The `permissions` block can be added at the root level of the workflow to apply to all jobs or individually for each job. In this case, adding permissions at the root level is sufficient and ensures consistency across all jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
